### PR TITLE
Support sentence-transformers

### DIFF
--- a/example/basic/wordlevel.go
+++ b/example/basic/wordlevel.go
@@ -37,7 +37,7 @@ func (pt *customPreTokenizer) PreTokenize(pretokenized *tokenizer.PreTokenizedSt
 		// split on punctuation
 		for _, sub := range wsSubs {
 			// puncSubs := sub.Split(normalizer.NewFnPattern(normalizer.IsPunctuation), normalizer.IsolatediBehavior)
-			puncSubs := sub.Split(normalizer.NewFnPattern(unicode.IsPunct), normalizer.IsolatediBehavior)
+			puncSubs := sub.Split(normalizer.NewFnPattern(unicode.IsPunct), normalizer.IsolatedBehavior)
 			splits = append(splits, puncSubs...)
 		}
 

--- a/pretrained/padding.go
+++ b/pretrained/padding.go
@@ -11,10 +11,15 @@ func CreatePaddingParams(config map[string]interface{}) (*tokenizer.PaddingParam
 	}
 
 	params := util.NewParams(config)
-	strategyName := params.Get("strategy").(string)
-	// TODO. verify???
-	strategySize := int(params.Get("size").(float64))
 	var strategy *tokenizer.PaddingStrategy
+
+	var strategyName string
+	var strategySize int
+	for k, v := range params.Get("strategy").(map[string]interface{}) {
+		strategyName = k
+		strategySize = int(v.(float64))
+	}
+
 	switch strategyName {
 	case "BatchLongest":
 		opt := tokenizer.WithBatchLongest()

--- a/pretrained/tokenizer_test.go
+++ b/pretrained/tokenizer_test.go
@@ -371,3 +371,21 @@ func TestLlamaDecode(t *testing.T) {
 		t.Errorf("\nwant %q\ngot  %q\n", want, got)
 	}
 }
+
+func TestSBert(t *testing.T) {
+	configFile, err := tokenizer.CachedPath("sentence-transformers/all-MiniLM-L12-v2", "tokenizer.json")
+	if err != nil {
+		panic(err)
+	}
+
+	tk, err := FromFile(configFile)
+	if err != nil {
+		panic(err)
+	}
+
+	sentence := `The Gophers craft code using [MASK] language.`
+	_, err = tk.EncodeSingle(sentence, true)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
There is some difference between `sentence-transformers/all-MiniLM-L12-v2` and `bert-base-uncased/tokenizer.json`.

```bash
diff sentence-transformers/tokenizer.json bert-base-uncased/tokenizer.json
```
```diff
< {"version":"1.0","truncation":{"max_length":128,"strategy":"LongestFirst","stride":0},"padding":{"strategy":{"Fixed":128},"direction":"Right","pad_to_multiple_of":null,"pad_id":0,"pad_type_id":0,"pad_token":"[PAD]"},"added_tokens":[{"id":0,"special":true,"content":"[PAD]","single_word":false,"lstrip":false,"rstrip":false,"normalized":false},{"id":100,"special":true,"content":"[UNK]","single_word":false,"lstrip":false,"rstrip":false,"normalized":false},{"id":101,"special":true,"content":"[CLS]","single_wor\ No newline at end of file
---
> {"version":"1.0","truncation":null,"padding":null,"added_tokens":[{"id":0,"special":true,"content":"[PAD]","single_word":false,"lstrip":false,"rstrip":false,"normalized":false},{"id":100,"special":true,"content":"[UNK]","single_word":false,"lstrip":false,"rstrip":false,"normalized":false},{"id":101,"special":true,"content":"[CLS]","single_word":false,"lstrip":false,"rstrip":false,"normalized":false},{"id":102,"special":true,"content":"[SEP]","single_word":false,"lstrip":false,"rstrip":false,"normalized":f\ No newline at end of file
```

Because of `"padding":{"strategy":{"Fixed":128}`, it fails. 793eb3679937ba487d0e2564b241be6685cb03cf fixed it.

However, test case added in a261e6a55313d0ac6109feb5844dbf1d8e0c342e still fails.
```
--- FAIL: TestSBert (0.03s)
panic: runtime error: index out of range [116] with length 116 [recovered]
	panic: runtime error: index out of range [116] with length 116

goroutine 6 [running]:
testing.tRunner.func1.2({0x1030038c0, 0x14000018ca8})
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1526 +0x1c8
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1529 +0x384
panic({0x1030038c0, 0x14000018ca8})
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/runtime/panic.go:884 +0x204
github.com/sugarme/tokenizer.(*Encoding).pad(0x140001bfa30, 0x80, 0x0, 0x0, {0x14000017036, 0x5}, 0xc?)
	/Users/yujonglee/dev/tokenizer/encoding.go:612 +0x74c
github.com/sugarme/tokenizer.(*Encoding).Pad(0x140001bfa30, 0x80, 0x1400010e790?, 0x14000170040?, {0x14000017036, 0x5}, 0x140001a6de8?)
	/Users/yujonglee/dev/tokenizer/encoding.go:566 +0x220
github.com/sugarme/tokenizer.PadEncodings({0x1400015d6c0?, 0x1, 0xa?}, {{{0x102fb8620, 0x1031ddd60}, {0x102f06e2c, 0x5}}, 0x0, 0x0, 0x0, ...})
	/Users/yujonglee/dev/tokenizer/util.go:175 +0x1c4
github.com/sugarme/tokenizer.(*Tokenizer).PostProcess(0x14000118000, 0x1400015cb60?, 0x0?, 0x1?)
	/Users/yujonglee/dev/tokenizer/tokenizer.go:624 +0x1f8
github.com/sugarme/tokenizer.(*Tokenizer).Encode(0x102fd8ba0?, {0x102fd8ba0?, 0x140000602e0?}, 0x0?)
	/Users/yujonglee/dev/tokenizer/tokenizer.go:464 +0x27c
github.com/sugarme/tokenizer.(*Tokenizer).EncodeSingle(0x1400001e420?, {0x102f180ad?, 0x102f0a06d?}, {0x1400011df47?, 0x13540c13c3787?, 0x1400eb198c0?})
	/Users/yujonglee/dev/tokenizer/tokenizer.go:1085 +0x94
github.com/sugarme/tokenizer/pretrained.TestSBert(0x0?)
	/Users/yujonglee/dev/tokenizer/pretrained/tokenizer_test.go:387 +0x70
testing.tRunner(0x1400016e1a0, 0x103022670)
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1576 +0x10c
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1629 +0x368
FAIL	github.com/sugarme/tokenizer/pretrained	0.472s
FAIL
```