### PR TITLE
Fix initialization issue in for loop to retain first token in output …

### DIFF
--- a/decoder/wordpiece.go
+++ b/decoder/wordpiece.go
@@ -81,7 +81,7 @@ func (wd *WordPieceDecoder) Cleanup(tok string) string {
 func (wd *WordPieceDecoder) DecodeChain(tokens []string) []string {
 	var toks []string
 	for i, token := range tokens {
-		var tok string
+		var tok string = token
 		if i != 0 {
 			if strings.HasPrefix(token, wd.prefix) {
 				tok = strings.Replace(token, wd.prefix, "", 1)


### PR DESCRIPTION
…string

This commit addresses an issue in the library where the first token of the output string was inadvertently being omitted. The problem originated from an incorrect initialization of the variable in a for loop. Specifically, the developer had initially used `var tok string` as the initialization, which resulted in the first token being removed due to a subsequent condition in the loop.

______

This pull request addresses a bug that affects the output string generation in the library. The bug was caused by an error in the initialization of a variable within a for loop, resulting in the omission of the first token from the output.

To fix this issue, I have made a simple adjustment by changing the initialization statement from `var tok string` to `var tok string = token`. This modification ensures that the first token is properly included in the output string, as intended.

I have tested the changes thoroughly and verified that the output now includes the first token as expected. Additionally, I have ensured that all existing tests pass successfully with the updated code.

Please review the changes and merge this pull request into the main branch.