### PR TITLE
use stdlib utf8 for validateRange; add tests

### DIFF
--- a/normalizer/normalizer_test.go
+++ b/normalizer/normalizer_test.go
@@ -1,0 +1,64 @@
+package normalizer
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_validateRange(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		s          string
+		inputRange *Range
+		want       *Range
+	}{
+		{
+			name:       "Valid range 0,4",
+			s:          "Lion Löwe 老虎 Léopard",
+			inputRange: NewRange(0, 4, OriginalTarget),
+			want:       NewRange(0, 4, OriginalTarget),
+		},
+		{
+			name:       "Valid range 0,3",
+			s:          "老",
+			inputRange: NewRange(0, 3, OriginalTarget),
+			want:       NewRange(0, 3, OriginalTarget),
+		},
+		{
+			name:       "Valid range 10,13",
+			s:          "Lion Löwe 老虎 Léopard",
+			inputRange: NewRange(11, 14, OriginalTarget),
+			want:       NewRange(11, 14, OriginalTarget),
+		},
+		// character is 3 bytes, so 1-2 is invalid
+		{
+			name:       "Invalid range",
+			s:          `老`,
+			inputRange: NewRange(1, 2, OriginalTarget),
+			want:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := NewNormalizedFrom(tt.s)
+			got := ns.validateRange(tt.inputRange)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Expected range %v, got %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Benchmark_validateRange(b *testing.B) {
+	s := "Lion Löwe 老虎 Léopard"
+	ns := NewNormalizedFrom(s)
+
+	var r *Range
+	for i := 0; i < b.N; i++ {
+		r = ns.validateRange(NewRange(0, len(s), NormalizedTarget))
+	}
+
+	_ = r
+}


### PR DESCRIPTION
Use the stdlib utf8 for validating the range. This causes a massive speed improvement for a function used in a very hot loop.

```
goos: linux
goarch: arm64
pkg: github.com/sugarme/tokenizer/normalizer
                 │ bench_validate_old.txt │       bench_validate_new.txt        │
                 │         sec/op         │   sec/op     vs base                │
_validateRange-3             381.00n ± 1%   16.67n ± 2%  -95.63% (p=0.000 n=10)

                 │ bench_validate_old.txt │       bench_validate_new.txt       │
                 │          B/op          │    B/op     vs base                │
_validateRange-3             1536.00 ± 0%   24.00 ± 0%  -98.44% (p=0.000 n=10)

                 │ bench_validate_old.txt │       bench_validate_new.txt       │
                 │       allocs/op        │ allocs/op   vs base                │
_validateRange-3               7.000 ± 0%   1.000 ± 0%  -85.71% (p=0.000 n=10)
```

Introduced tests that were missing for this function.