### PR TITLE
fix(cache): race condition detected when batch tokenizr executions.

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -25,7 +25,7 @@ func ExampleTokenizer_Encode() {
 	// offsets: [[0 9] [10 11] [12 15] [16 17] [18 24] [25 28] [29 33]]
 }
 
-func ExamplePreTokenizer_Split() {
+func ExampleTokenizer_EncodeSingle() {
 
 	tk := pretrained.BertBaseUncased()
 

--- a/model/bpe/bpe.go
+++ b/model/bpe/bpe.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+
 	// "strconv"
 	"log"
 	"strings"
@@ -194,23 +195,6 @@ type BPE struct {
 
 func (b *BPE) builder() *BpeBuilder {
 	return NewBpeBuilder()
-}
-
-// new create a BPE with default values
-func (b *BPE) new() {
-	var err error
-	b, err = b.builder().Build()
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
-// `Clone` can't be derive because it's not implemented for `Cache`.
-// To keep things simple when we clone, the new BPE will start with a fresh cache.
-func (b *BPE) clone() {
-	newBpe := b
-	newBpe.Cache.Fresh()
-	b = newBpe
 }
 
 // newBPE create a default BPE from sratch using its pbeBuilder

--- a/model/bpe/cache.go
+++ b/model/bpe/cache.go
@@ -31,50 +31,65 @@ func NewCache(capacity int) *Cache {
 	}
 }
 
-// Fresh create a fresh `Cache` with the same configuration
-func (c *Cache) Fresh() {
-	c = NewCache(c.Capacity)
-}
-
 // Clear clears the cache
 func (c *Cache) Clear() {
-	// NOTE:Should we just make a new map instead of use `for` loop
-	// Ref. https://stackoverflow.com/questions/13812121
-	for k := range c.cmap {
-		delete(c.cmap, k)
-	}
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	// Create a new map instead of using delete loop
+	c.cmap = make(map[string]Word, c.Capacity)
 }
 
 // GetValues returns slices of values associated with input keys
 func (c *Cache) GetValues(keys []string) []Word {
-	c.mux.Lock() // Lock so only one goroutine at a time can access
-	defer c.mux.Unlock()
+	c.mux.RLock() // Use read lock for concurrent reads
+	defer c.mux.RUnlock()
 
 	var res []Word
+	res = make([]Word, len(keys)) // Pre-allocate slice for better performance
 
-	for _, k := range keys {
-		res = append(res, c.cmap[k])
+	for i, k := range keys {
+		res[i] = c.cmap[k]
 	}
 
 	return res
 }
 
+// SetValues sets values in the cache, respecting capacity limits
 func (c *Cache) SetValues(values []CacheItem) {
-
-	// Before trying to acquire a write lock, we check if we are already at
-	// capacity with a read handler.
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
-	if len(c.cmap) == c.Capacity {
+	// Check if we're already at capacity
+	if len(c.cmap) >= c.Capacity {
 		return
 	}
 
-	for _, v := range values {
-		if len(c.cmap) == c.Capacity {
+	// Calculate how many items we can add
+	remaining := c.Capacity - len(c.cmap)
+	if remaining <= 0 {
+		return
+	}
+
+	// Add items up to capacity
+	for i, v := range values {
+		if i >= remaining {
 			break
 		}
-
 		c.cmap[v.Key] = v.Value
 	}
+}
+
+// GetSize returns the current number of items in the cache
+func (c *Cache) GetSize() int {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	return len(c.cmap)
+}
+
+// IsFull returns true if the cache has reached its capacity
+func (c *Cache) IsFull() bool {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	return len(c.cmap) >= c.Capacity
 }

--- a/model/bpe/cache_test.go
+++ b/model/bpe/cache_test.go
@@ -1,0 +1,292 @@
+package bpe
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestNewCache(t *testing.T) {
+	capacity := 10
+	cache := NewCache(capacity)
+
+	if cache.Capacity != capacity {
+		t.Errorf("Expected capacity %d, got %d", capacity, cache.Capacity)
+	}
+
+	if len(cache.cmap) != 0 {
+		t.Errorf("Expected empty map, got map with %d items", len(cache.cmap))
+	}
+}
+
+func TestCache_Clear(t *testing.T) {
+	cache := NewCache(5)
+	word1 := NewWord()
+	word2 := NewWord()
+	cache.SetValues([]CacheItem{
+		{Key: "test1", Value: *word1},
+		{Key: "test2", Value: *word2},
+	})
+
+	cache.Clear()
+
+	if len(cache.cmap) != 0 {
+		t.Errorf("Expected empty map after Clear(), got map with %d items", len(cache.cmap))
+	}
+}
+
+func TestCache_GetValues(t *testing.T) {
+	cache := NewCache(5)
+	word1 := NewWord()
+	word2 := NewWord()
+	word3 := NewWord()
+	testItems := []CacheItem{
+		{Key: "test1", Value: *word1},
+		{Key: "test2", Value: *word2},
+		{Key: "test3", Value: *word3},
+	}
+	cache.SetValues(testItems)
+
+	tests := []struct {
+		name     string
+		keys     []string
+		expected []Word
+	}{
+		{
+			name:     "Get existing values",
+			keys:     []string{"test1", "test2"},
+			expected: []Word{*word1, *word2},
+		},
+		{
+			name:     "Get non-existing value",
+			keys:     []string{"nonexistent"},
+			expected: []Word{{}},
+		},
+		{
+			name:     "Get mixed existing and non-existing values",
+			keys:     []string{"test1", "nonexistent", "test3"},
+			expected: []Word{*word1, {}, *word3},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values := cache.GetValues(tt.keys)
+			if len(values) != len(tt.expected) {
+				t.Errorf("Expected %d values, got %d", len(tt.expected), len(values))
+				return
+			}
+			for i, v := range values {
+				if len(v.Symbols) != len(tt.expected[i].Symbols) {
+					t.Errorf("Expected value %v at index %d, got %v", tt.expected[i], i, v)
+				}
+			}
+		})
+	}
+}
+
+func TestCache_SetValues(t *testing.T) {
+	tests := []struct {
+		name           string
+		capacity       int
+		initialItems   []CacheItem
+		itemsToAdd     []CacheItem
+		expectedLength int
+	}{
+		{
+			name:     "Add items within capacity",
+			capacity: 5,
+			itemsToAdd: []CacheItem{
+				{Key: "test1", Value: *NewWord()},
+				{Key: "test2", Value: *NewWord()},
+			},
+			expectedLength: 2,
+		},
+		{
+			name:     "Add items exceeding capacity",
+			capacity: 2,
+			itemsToAdd: []CacheItem{
+				{Key: "test1", Value: *NewWord()},
+				{Key: "test2", Value: *NewWord()},
+				{Key: "test3", Value: *NewWord()},
+			},
+			expectedLength: 2,
+		},
+		{
+			name:     "Add items to full cache",
+			capacity: 2,
+			initialItems: []CacheItem{
+				{Key: "test1", Value: *NewWord()},
+				{Key: "test2", Value: *NewWord()},
+			},
+			itemsToAdd: []CacheItem{
+				{Key: "test3", Value: *NewWord()},
+			},
+			expectedLength: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := NewCache(tt.capacity)
+			if len(tt.initialItems) > 0 {
+				cache.SetValues(tt.initialItems)
+			}
+			cache.SetValues(tt.itemsToAdd)
+
+			if len(cache.cmap) != tt.expectedLength {
+				t.Errorf("Expected %d items in cache, got %d", tt.expectedLength, len(cache.cmap))
+			}
+		})
+	}
+}
+
+func TestCache_GetSize(t *testing.T) {
+	cache := NewCache(5)
+	word1 := NewWord()
+	word2 := NewWord()
+	cache.SetValues([]CacheItem{
+		{Key: "test1", Value: *word1},
+		{Key: "test2", Value: *word2},
+	})
+
+	size := cache.GetSize()
+	if size != 2 {
+		t.Errorf("Expected size 2, got %d", size)
+	}
+}
+
+func TestCache_IsFull(t *testing.T) {
+	cache := NewCache(2)
+	word1 := NewWord()
+	word2 := NewWord()
+	cache.SetValues([]CacheItem{
+		{Key: "test1", Value: *word1},
+		{Key: "test2", Value: *word2},
+	})
+
+	full := cache.IsFull()
+	if !full {
+		t.Errorf("Expected cache to be full, but it is not")
+	}
+}
+
+func TestCache_ConcurrentReads(t *testing.T) {
+	t.Parallel()
+
+	cache := NewCache(100)
+	word := NewWord()
+
+	// Fill cache with some initial data
+	for i := 0; i < 50; i++ {
+		cache.SetValues([]CacheItem{
+			{Key: "test" + string(rune(i)), Value: *word},
+		})
+	}
+
+	var wg sync.WaitGroup
+	readers := 100
+	iterations := 1000
+
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				// Generate random keys to read
+				keys := make([]string, 5)
+				for k := 0; k < 5; k++ {
+					keys[k] = "test" + string(rune(j%50))
+				}
+				_ = cache.GetValues(keys)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestCache_ConcurrentWrites(t *testing.T) {
+	t.Parallel()
+
+	cache := NewCache(100)
+	word := NewWord()
+
+	var wg sync.WaitGroup
+	writers := 10
+	iterations := 100
+
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		go func(writerID int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				key := "test" + string(rune(writerID)) + string(rune(j))
+				cache.SetValues([]CacheItem{
+					{Key: key, Value: *word},
+				})
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify that the cache size is within capacity
+	if len(cache.cmap) > cache.Capacity {
+		t.Errorf("Cache size %d exceeds capacity %d", len(cache.cmap), cache.Capacity)
+	}
+}
+
+func TestCache_ConcurrentReadsAndWrites(t *testing.T) {
+	t.Parallel()
+
+	cache := NewCache(100)
+	word := NewWord()
+
+	// Fill cache with some initial data
+	for i := 0; i < 50; i++ {
+		cache.SetValues([]CacheItem{
+			{Key: "test" + string(rune(i)), Value: *word},
+		})
+	}
+
+	var wg sync.WaitGroup
+	readers := 50
+	writers := 10
+	iterations := 100
+
+	// Start readers
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				keys := make([]string, 5)
+				for k := 0; k < 5; k++ {
+					keys[k] = "test" + string(rune(j%50))
+				}
+				_ = cache.GetValues(keys)
+			}
+		}()
+	}
+
+	// Start writers
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		go func(writerID int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				key := "test" + string(rune(writerID)) + string(rune(j))
+				cache.SetValues([]CacheItem{
+					{Key: key, Value: *word},
+				})
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify that the cache size is within capacity
+	if len(cache.cmap) > cache.Capacity {
+		t.Errorf("Cache size %d exceeds capacity %d", len(cache.cmap), cache.Capacity)
+	}
+}


### PR DESCRIPTION
# Context

I was using the fastembed-go library from [fastembed-go](https://github.com/Anush008/fastembed-go) and discovered a race condition while attempting to batch the processing.

# Reference(s)

- fix https://github.com/sugarme/tokenizer/issues/32