### PR TITLE
fix(normalizer): Prevent panic in TransformRange with multi-byte characters

### DIFF
--- a/normalizer/normalized.go
+++ b/normalizer/normalized.go
@@ -552,7 +552,7 @@ func (n *NormalizedString) TransformRange(inputRange *Range, changeMap []ChangeM
 	// oShift is the shift to be applied to all original alignments along the way
 	// NOTE. `oShift` and `offset` here are different from ones inside previous block
 	oShift := -(initialRemoved)
-	offset := initialRemoved + nRange.start
+	runeIndex := 0
 	var normalizedAlignments [][]int
 
 	// log.Printf("Applying transformations...\n")
@@ -578,19 +578,18 @@ func (n *NormalizedString) TransformRange(inputRange *Range, changeMap []ChangeM
 		 *     // log.Printf("### '%v' with size %v : %v with offset %v ###\n", item.RuneVal, len(item.RuneVal), changeType, offset)
 		 *     fmt.Printf("'%v' - changes: %v\n", item.RuneVal, item.Changes)
 		 *  */
-		idx := offset
 		// fmt.Printf("idx: %v\n", idx)
 		var align []int
 		if item.Changes > 0 {
-			if idx < 1 {
+			if runeIndex < 1 {
 				align = []int{0, 0}
 			} else {
 				// This is a newly inserted character, so it shares the same alignment
 				// as the previous one
-				align = n.alignments[idx-1]
+				align = n.alignments[runeIndex-1]
 			}
 		} else {
-			align = n.alignments[idx]
+			align = n.alignments[runeIndex]
 		}
 
 		// If we are replacing a character, find it and compute the change in size
@@ -639,8 +638,8 @@ func (n *NormalizedString) TransformRange(inputRange *Range, changeMap []ChangeM
 
 		var removingFromOriginal, removingFromNormalized int = 0, 0
 		if totalBytesToRemove > 0 {
-			start := n.alignments[idx][1]
-			end := n.alignments[idx+totalBytesToRemove][1]
+			start := n.alignments[runeIndex][1]
+			end := n.alignments[runeIndex+totalBytesToRemove][1]
 			originalRange := util.MakeRange(start, end)
 			// fmt.Printf("start: %v - end: %v; range: (%+v)\n", start, end, originalRange)
 			removingFromOriginal = len(originalRange)
@@ -715,8 +714,8 @@ func (n *NormalizedString) TransformRange(inputRange *Range, changeMap []ChangeM
 
 		// If some were removed, we need to zero them out in the original alignments
 		if removingFromOriginal > 0 {
-			start := n.alignments[idx][1]
-			end := n.alignments[idx+totalBytesToRemove][1]
+			start := n.alignments[runeIndex][1]
+			end := n.alignments[runeIndex+totalBytesToRemove][1]
 			// They should use the original alignment of the current character
 			newIdx := n.alignmentsOriginal[align[0]][1]
 			alignments := n.alignmentsOriginal[start:end]
@@ -736,8 +735,8 @@ func (n *NormalizedString) TransformRange(inputRange *Range, changeMap []ChangeM
 		}
 
 		// Keep track of the changes for next offsets
-		offset += replacedCharSize
-		offset += totalBytesToRemove
+		runeIndex++
+		
 		// For the original only the real modifications count
 		oShift += replacedCharSizeChange
 		oShift -= totalBytesToRemove


### PR DESCRIPTION
# fix(normalizer): Prevent panic in TransformRange with multi-byte characters
# 修复(normalizer): 防止 TransformRange 在处理多字节字符时发生 Panic

## Summary
This PR fixes a critical panic in normalizer.TransformRange that occurs when processing strings containing multi-byte UTF-8 characters (e.g., Chinese, Emojis).
## The Problem
The application would panic with an "index out of range" error when TransformRange was called on a NormalizedString containing multi-byte characters.
## Root Cause Analysis
The function incorrectly used a byte-based offset (offset + i) to access the n.alignments slice, which is indexed by runes (characters). For multi-byte characters, the byte offset increases faster than the rune count, leading to an out-of-bounds access.
## The Fix
- A new variable, runeIndex, is introduced to explicitly track the character (rune) position during iteration.
- All accesses to n.alignments are updated to use this correct runeIndex instead of the faulty byte-based offset.
- This change is minimal and targeted, resolving the panic without altering the function's core logic.

## 摘要
本 PR 修复了在 normalizer.TransformRange 中处理包含多字节 UTF-8 字符（如中文字符、Emoji 等）的字符串时发生的严重 Panic 问题。
## 问题描述
当 TransformRange 函数处理包含多字节字符的 NormalizedString 时，程序会因“索引越界”错误而崩溃。
## 根本原因分析
该函数错误地使用了基于字节的偏移量（offset + i）来访问 n.alignments 切片，而该切片本应根据 rune（字符）进行索引。对于多字节字符，字节偏移量的增长速度超过了字符数的增长，最终导致了越界访问。
## 修复方案
- 引入了一个新变量 runeIndex，用于在迭代过程中显式跟踪字符（rune）的位置。
- 将所有对 n.alignments 的访问都更新为使用正确的 runeIndex，而不是之前错误的字节偏移量。
- 此改动是最小化且目标明确的，在不改变函数核心逻辑的情况下解决了 Panic 问题。