### PR TITLE
Enable Precompiled Normalizer

### DIFF
--- a/pretrained/normalizer_test.go
+++ b/pretrained/normalizer_test.go
@@ -55,3 +55,16 @@ func TestNullNormalizer(t *testing.T) {
 		panic(err)
 	}
 }
+
+func TestCreatePrecompiledNormalizer(t *testing.T) {
+	modelName := "MoritzLaurer/deberta-v3-base-zeroshot-v1"
+	config, err := loadConfig(modelName)
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = CreateNormalizer(config.Normalizer)
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Spotted that Precompiled threw a not implemented error, but the spm code was already in the repo. Enabled it to try it out, and for me (combined with the unigram branch) MoritzLaurer/deberta-v3-base-zeroshot-v1 now fully works and matches the rust reference output.