### PR TITLE
fix(model/wordpiece): prevent assignment to nil map

### DIFF
--- a/model/wordpiece/wordpiece.go
+++ b/model/wordpiece/wordpiece.go
@@ -152,10 +152,10 @@ func (wp WordPiece) ReadFiles(filename string) (retVal model.Vocab) {
 	defer file.Close()
 
 	var (
-		vocab model.Vocab
-		line  string
-		idx   int = 0
+		line string
+		idx  int = 0
 	)
+	vocab := make(model.Vocab)
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {


### PR DESCRIPTION
This prevents the assignment of a value to a `nil` map, which can cause a panic.