### PR TITLE
Fix idx out-of-bounds panic in TransformRange

### DIFF
--- a/normalizer/normalized.go
+++ b/normalizer/normalized.go
@@ -640,7 +640,8 @@ func (n *NormalizedString) TransformRange(inputRange *Range, changeMap []ChangeM
 		//      and are just part of the normalized string
 
 		var removingFromOriginal, removingFromNormalized int = 0, 0
-		if totalBytesToRemove > 0 {
+		// Guard: idx may equal len(n.alignments) when removals fall at the very end of the string.
+		if totalBytesToRemove > 0 && idx < len(n.alignments) {
 			start := n.alignments[idx][1]
 			// Bounds check to prevent index out of range panic
 			endIdx := idx + totalBytesToRemove


### PR DESCRIPTION
This branch contains two commits that together fix all known index-out-of-range
panics in `TransformRange` in `normalizer/normalized.go`:

1. **Fix index out of range when `idx+totalBytesToRemove` exceeds alignments**
   (originally PR #76) — already merged to master.
2. **Fix index out of range when `idx` itself equals `len(n.alignments)`** — the
   remaining gap. When the changeMap iterator reaches the last character and that
   character carries removals, `offset` can already equal `len(n.alignments)`.
   The PR #76 guard covered `idx+totalBytesToRemove` but not `idx` itself, so
   `n.alignments[idx]` still panicked.

The fix adds `idx < len(n.alignments)` to the outer condition so the entire
removal block is skipped when `idx` is at or past the end.

## Reproduction

Occurs when tokenizing certain Unicode-heavy strings (e.g. long Danish/Nordic
content) with the Nomic v2 BPE tokenizer config. Triggered reliably when
processing ~350 real-world documents.